### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/bibchex/checks/common.py
+++ b/bibchex/checks/common.py
@@ -1,7 +1,7 @@
 from bibchex.config import Config
 from bibchex.strutil import AbbrevFinder
 from itertools import combinations
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 
 class GenericFuzzySimilarityChecker(object):
@@ -34,7 +34,7 @@ class GenericFuzzySimilarityChecker(object):
         problems = []
         for (n1, n2) in combinations(
                 GenericFuzzySimilarityChecker.SEEN_NAMES[name], 2):
-            if fuzz.partial_ratio(n1, n2) > 95:  # TODO make configurable
+            if fuzz.partial_ratio(n1, n2, score_cutoff=95):  # TODO make configurable
                 problems.append((name,
                                  "{} names '{}' and '{}' seem very similar."
                                  .format(cls.MSG_NAME, n1, n2),

--- a/bibchex/sources/crossref.py
+++ b/bibchex/sources/crossref.py
@@ -6,7 +6,7 @@ from functools import partial
 
 import crossref_commons.retrieval
 import crossref_commons.search
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from ratelimit import RateLimitException
 
 from bibchex.data import Suggestion
@@ -94,9 +94,9 @@ class CrossrefSource(object):
                 suggested_title = results[i]['title']
                 doi = results[i]['DOI']
 
-                fuzz_score = fuzz.partial_ratio(title, suggested_title)
-                if fuzz_score >= self._cfg.get('doi_fuzzy_threshold', entry,
-                                               90):
+                score_cutoff = self._cfg.get('doi_fuzzy_threshold', entry, 90)
+                if fuzz.partial_ratio(title, suggested_title,
+                                      score_cutoff=score_cutoff):
                     return doi
 
             return None

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=["aiohttp>=3.6.2",
                       "bibtexparser>=1.1.0",
                       "crossref-commons-reverse>=0.0.7.1",
-                      "fuzzywuzzy==0.18.0",
+                      "rapidfuzz==0.9.1",
                       "isbnlib>=3.10.3",
                       "Jinja2>=2.11.1",
                       "nameparser>=1.0.6",


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy